### PR TITLE
Bump KOTLIN_VERSION from 1.8.0 to 2.1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        KOTLIN_VERSION = "1.8.0"
+        KOTLIN_VERSION = "2.1.10"
         KETHEREUM_VERSION = "0.85.7"
     }
 


### PR DESCRIPTION
Bumps `KOTLIN_VERSION` from 1.8.0 to 2.1.10.

Updates `org.jetbrains.kotlin:kotlin-gradle-plugin` from 1.8.0 to 2.1.10
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.8.0...v2.1.10)

Updates `org.jetbrains.kotlin:kotlin-stdlib` from 1.8.0 to 2.1.10
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.8.0...v2.1.10)

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.jetbrains.kotlin:kotlin-stdlib dependency-type: direct:production update-type: version-update:semver-major ...